### PR TITLE
Specify Bazel Version Matrix for CI 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,7 @@ before_install:
   - echo $TRAVIS_OS_NAME;
   - unset CC
   - unset CXX
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get autoremove openjdk-9-jre-headless openjdk-9-jdk oracle-java9-installer; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get purge openjdk-9-jre-headless openjdk-9-jdk oracle-java9-installer; fi
-  - mkdir -p ${HOME}/bazel/install
-  - pushd ${HOME}/bazel/install
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget --no-clobber https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo dpkg -i bazel_${BAZEL_VERSION}-linux-x86_64.deb; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bazel; fi
-  - popd
+  - scripts/install_bazel.sh
 
 script:
   - bazel test --crosstool_top=//tools/cpp:default-toolchain //src/...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,15 @@
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      sudo: required
-      language: java
-    - os: osx
-      osx_image: xcode8.3
-      language: java
+dist: trusty
+sudo: required
+osx_image: xcode8.3
+language: java
+
+os:
+  - linux
+  - osx
 
 env:
-  global:
-    - BAZEL_VERSION=0.9.0
-    - BAZEL_VERSION=0.11.1
+  - BAZEL_VERSION=0.9.0
+  - BAZEL_VERSION=0.11.1
 
 before_install:
   - echo $TRAVIS_OS_NAME;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
 env:
   global:
     - BAZEL_VERSION=0.9.0
+    - BAZEL_VERSION=0.11.1
 
 before_install:
   - echo $TRAVIS_OS_NAME;

--- a/scripts/install_bazel.sh
+++ b/scripts/install_bazel.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
+#
+# This script installs Bazel for Debian or MacOS for usage in the Travis CI environment.
+#
+# Required config:
+# - CI
+# - TRAVIS
+# - TRAVIS_OS_NAME
+# - BAZEL_VERSION: Bazel version to install
+#
+# Optional configs:
+# - BAZEL_INSTALL: Location to fetch the installers to, default: ${HOME}/bazel/install
+#
 set -e
 
-LOCAL_OS="$(uname)"
+if [ -z "$CI" ] || [ -z "$TRAVIS" ]; then
+    echo "error: this is intended to be run under travis-ci, exiting..."
+    exit 1;
+fi
 
 if [ -z "$BAZEL_VERSION" ]; then
-   BAZEL_VERSION="0.11.1"
+    echo "error: BAZEL_VERSION required, exiting..."
+    exit 1;
 fi
 
 if [ -z "$BAZEL_INSTALL" ]; then
@@ -14,17 +30,19 @@ fi
 mkdir -p $BAZEL_INSTALL
 pushd $BAZEL_INSTALL
 
-if [ "$LOCAL_OS" == "Linux" ]; then
+if [ "$TRAVIS_OS_NAME" == "linux" ]; then
     echo "Installing Bazel ${BAZEL_VERSION} for Linux"
-    wget --no-clobber "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb"
-    sudo dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb"
-elif [ "$LOCAL_OS" == "Darwin" ]; then
+    DEBIAN_PACKAGE_NAME="bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+    wget --no-clobber "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${DEBIAN_PACKAGE_NAME}"
+    sudo dpkg -i ${DEBIAN_PACKAGE_NAME}
+elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
     echo "Installing Bazel ${BAZEL_VERSION} for Darwin"
-    curl -sLO https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh
-    chmod +x bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh
-    ./bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh --user
+    DARWIN_INSTALL_SCRIPT=bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh
+    curl -sLO https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${DARWIN_INSTALL_SCRIPT}
+    chmod +x ${DARWIN_INSTALL_SCRIPT}
+    ./${DARWIN_INSTALL_SCRIPT} --user
 else
-    echo "Unsupported OS"
+    echo "error: unsupported TRAVIS_OS_NAME: ${TRAVIS_OS_NAME}, exiting"
     exit 1;
 fi
 

--- a/scripts/install_bazel.sh
+++ b/scripts/install_bazel.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -e
+
+LOCAL_OS="$(uname)"
+
+if [ -z "$BAZEL_VERSION" ]; then
+   BAZEL_VERSION="0.11.1"
+fi
+
+if [ -z "$BAZEL_INSTALL" ]; then
+   BAZEL_INSTALL="${HOME}/bazel/install"
+fi
+
+mkdir -p $BAZEL_INSTALL
+pushd $BAZEL_INSTALL
+
+if [ "$LOCAL_OS" == "Linux" ]; then
+    echo "Installing Bazel ${BAZEL_VERSION} for Linux"
+    wget --no-clobber "https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+    sudo dpkg -i "bazel_${BAZEL_VERSION}-linux-x86_64.deb"
+elif [ "$LOCAL_OS" == "Darwin" ]; then
+    echo "Installing Bazel ${BAZEL_VERSION} for Darwin"
+    curl -sLO https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh
+    chmod +x bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh
+    ./bazel-${BAZEL_VERSION}-without-jdk-installer-darwin-x86_64.sh --user
+else
+    echo "Unsupported OS"
+    exit 1;
+fi
+
+popd


### PR DESCRIPTION
Add `scripts/install_bazel.sh` helper to allow for testing multiple Bazel versions in CI and reorganize the travis configuration.

Internal ref: ML-1323