### PR TITLE
Remove usage of deprecated native repository rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,10 @@ workspace(name = "co_vsco_bazel_toolchains")
 load("//toolchains:repositories.bzl", "bazel_toolchains_repositories")
 bazel_toolchains_repositories()
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 # GTest
-new_http_archive(
+http_archive(
   name = "gtest",
   url = "https://github.com/google/googletest/archive/release-1.8.0.zip",
   sha256 = "f3ed3b58511efd272eb074a3a6d6fb79d7c2e6a0e374323d1e6bcbcc1ef141bf",

--- a/toolchains/repositories.bzl
+++ b/toolchains/repositories.bzl
@@ -16,6 +16,9 @@
 # Defines external repositories needed by bazel-toolchains.
 # Chromium toolchain corresponds to Chromium 64.0.3282.167.
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+
 def bazel_toolchains_repositories():
     org_chromium_clang_mac()
     org_chromium_clang_linux_x64()
@@ -25,7 +28,7 @@ def bazel_toolchains_repositories():
     org_chromium_libcxxabi()
 
 def org_chromium_clang_mac():
-    native.new_http_archive(
+    http_archive(
         name = 'org_chromium_clang_mac',
         build_file = str(Label('//build_files:org_chromium_clang_mac.BUILD')),
         sha256 = '4f0aca6ec66281be94c3045550ae15a73befa59c32396112abda0030ef22e9b6',
@@ -33,7 +36,7 @@ def org_chromium_clang_mac():
     )
 
 def org_chromium_clang_linux_x64():
-    native.new_http_archive(
+    http_archive(
         name = 'org_chromium_clang_linux_x64',
         build_file = str(Label('//build_files:org_chromium_clang_linux_x64.BUILD')),
         sha256 = 'e63e5fe3ec8eee4779812cd16aae0ddaf1256d2e8e93cdd5914a3d3e01355dc1',
@@ -41,7 +44,7 @@ def org_chromium_clang_linux_x64():
     )
 
 def org_chromium_sysroot_linux_x64():
-    native.new_http_archive(
+    http_archive(
         name = 'org_chromium_sysroot_linux_x64',
         build_file = str(Label('//build_files:org_chromium_sysroot_linux_x64.BUILD')),
         sha256 = '84656a6df544ecef62169cfe3ab6e41bb4346a62d3ba2a045dc5a0a2ecea94a3',
@@ -49,7 +52,7 @@ def org_chromium_sysroot_linux_x64():
     )
 
 def org_chromium_binutils_linux_x64():
-    native.new_http_archive(
+    http_archive(
         name = 'org_chromium_binutils_linux_x64',
         build_file = str(Label('//build_files:org_chromium_binutils_linux_x64.BUILD')),
         sha256 = '24c3df44af5bd377c701ee31b9b704f2ea23456f20e63652c8235a10d7cf1be7',
@@ -58,7 +61,7 @@ def org_chromium_binutils_linux_x64():
     )
 
 def org_chromium_libcxx():
-    native.new_git_repository(
+    new_git_repository(
         name = 'org_chromium_libcxx',
         build_file = str(Label('//build_files:org_chromium_libcxx.BUILD')),
         commit = 'f56f1bba1ade4a408d403ff050d50e837bae47df',
@@ -66,7 +69,7 @@ def org_chromium_libcxx():
     )
 
 def org_chromium_libcxxabi():
-    native.new_git_repository(
+    new_git_repository(
         name = 'org_chromium_libcxxabi',
         build_file = str(Label('//build_files:org_chromium_libcxxabi.BUILD')),
         commit = '05ba3281482304ae8de31123a594972a495da06d',


### PR DESCRIPTION
Per https://groups.google.com/d/msg/bazel-discuss/dO2MHQLwJF0/2OXHjMAaAAAJ the native rules are being removed.

Tested with ``` --incompatible_remove_native_http_archive --incompatible_remove_native_git_repository```